### PR TITLE
단일 게시글 조회 시 에러 발생 수정 및 코드 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ poetry run uvicorn main:app --reload
 - 게시글 생성 (Create Post)
 - 게시글 조회 (Get Post)
 - 게시글 목록 조회 (List Posts)
+- 게시글 수정 (Update Post)
+- 게시글 삭제 (Delete Post)

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ def verify_post_id(post_id: UUID) -> Post:
     """
     게시글 가져오기
     :param post_id: 게시글 ID
-    :return: 게시글 객체. 존재하지 않는 게시글 ID인 경우 404 에러를 발생시킵니다.
+    :return: 게시글 객체
     """
     post = post_data.get(post_id)
 
@@ -39,12 +39,12 @@ def verify_post_id(post_id: UUID) -> Post:
     return post
 
 
-def verify_author(post_id: UUID, token: str | None = Cookie(None)) -> None:
+def verify_author(post_id: UUID, token: str | None = Cookie(None)) -> Post:
     """
     게시글 작성자 확인
     :param token: 사용자의 토큰
     :param post_id: 게시글 ID
-    :return: None
+    :return: 게시글 객체
     """
     post = verify_post_id(post_id)
 
@@ -52,6 +52,8 @@ def verify_author(post_id: UUID, token: str | None = Cookie(None)) -> None:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="작성자만 접근 가능합니다."
         )
+
+    return post
 
 
 @app.get("/", status_code=status.HTTP_200_OK)

--- a/main.py
+++ b/main.py
@@ -1,11 +1,10 @@
 import secrets
-from datetime import datetime
 from uuid import UUID
 
 from fastapi import Cookie, Depends, FastAPI, HTTPException, status
 from starlette.responses import Response
 
-from schemas.base import ResponseModel
+from schemas.base import ResponseModel, _default_time
 from schemas.post import CreatePost, Post, ResponsePost, UpdatePost
 
 app = FastAPI()
@@ -125,7 +124,7 @@ def update_post(update_data: UpdatePost, post=Depends(verify_author)) -> Respons
             setattr(post, key, value)
 
     # 업데이트 시간 재설정
-    post.updated_at = datetime.utcnow()
+    post.updated_at = _default_time()
 
     return post
 

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from fastapi import Cookie, Depends, FastAPI, HTTPException, status
 from starlette.responses import Response
 
+from schemas.base import ResponseModel
 from schemas.post import CreatePost, Post, ResponsePost, UpdatePost
 
 app = FastAPI()
@@ -56,13 +57,17 @@ def read_root() -> Response:
     return response
 
 
-@app.get("/posts/", response_model=list[ResponsePost], status_code=status.HTTP_200_OK)
-def read_posts() -> list[ResponsePost]:
+@app.get(
+    "/posts/",
+    response_model=ResponseModel[ResponsePost],
+    status_code=status.HTTP_200_OK,
+)
+def read_posts() -> ResponseModel[ResponsePost]:
     """
     게시글 목록 조회
     :return: 게시글 목록과 각 게시글의 URL을 포함한 리스트를 반환합니다.
     """
-    return post_data.values()
+    return ResponseModel(count=len(post_data), items=post_data.values())
 
 
 @app.get(

--- a/main.py
+++ b/main.py
@@ -111,18 +111,13 @@ def create_post(post: CreatePost, token=Depends(get_token)) -> ResponsePost:
 @app.patch(
     "/posts/{post_id}", response_model=ResponsePost, status_code=status.HTTP_200_OK
 )
-def update_post(
-    post_id: UUID, update_data: UpdatePost, depends=Depends(verify_author)
-) -> ResponsePost:
+def update_post(update_data: UpdatePost, post=Depends(verify_author)) -> ResponsePost:
     """
     게시글 수정
     :param post_id: 수정할 게시글의 ID
     :param update_data: 수정할 게시글의 내용 (author, title, content)
     :return: 특정 ID를 가진 게시글의 내용을 수정합니다. 존재하지 않는 게시글 ID인 경우 404 에러를 발생시킵니다.
     """
-
-    # 수정을 위해 게시글 데이터 가져오기
-    post = post_data[post_id]
 
     # 게시글 내용 수정
     for key, value in update_data:
@@ -136,12 +131,12 @@ def update_post(
 
 
 @app.delete("/posts/{post_id}", status_code=status.HTTP_200_OK)
-def delete_post(post_id: UUID, depends=Depends(verify_author)) -> dict[str, str]:
+def delete_post(post=Depends(verify_author)) -> dict[str, str]:
     """
     게시글 삭제
     :param post_id: 삭제할 게시글의 ID
     :return: 특정 ID를 가진 게시글을 삭제합니다. 존재하지 않는 게시글 ID인 경우 404 에러를 발생시킵니다.
     """
-    del post_data[post_id]
+    del post_data[post.id]
 
     return {"message": "게시글이 삭제되었습니다."}

--- a/schemas/base.py
+++ b/schemas/base.py
@@ -1,7 +1,9 @@
 from datetime import datetime, timezone
-from typing import Annotated
+from typing import Annotated, Generic, TypeVar
 
-from pydantic import Field, BaseModel
+from pydantic import BaseModel, Field
+
+T = TypeVar("T")
 
 
 def _default_time():
@@ -10,6 +12,11 @@ def _default_time():
 
 def _change_local_time(time: datetime):
     return time.astimezone()
+
+
+class ResponseModel(BaseModel, Generic[T]):
+    count: int
+    items: list[T]
 
 
 class TimeMixin(BaseModel):


### PR DESCRIPTION
**[ 에러 수정 ]**
- 단일 게시글 조회 시, 500에러 발생 현상 수정
- 게시글 업데이트 시, `naive datetime` 로 설정되어 Timezone이 적용되지 않는 현상 수정 **[멘토님 리뷰 외 추가 개선 작업]**

**[ 코드 개선 ]**
- 단일 게시글의 Read/Update/Delete 시, `Depends` 를 사용한 `Post` 객체를 바로 사용할 수 있도록 수정 **[멘토님 리뷰 외 추가 개선 작업]**
- 여러 게시글 반환 시, 단순 리스트가 아닌 별도의 Response Frame을 가진 Dict 형태로 반환(`ResponseModel` 추가 작성 및 적용)
- 미사용 `__init__` 파일 삭제
- README 파일 수정

[이전 PR](https://github.com/f-lab-edu/FastAPI-Board/pull/5)